### PR TITLE
Fixes for default database name & locating polldata.json on p&l and trade history tab.

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
     "schema": "tf2",
     "host": "localhost",
     "port": 5432,
-    "name": "bptf-autopricer",
+    "name": "tf2autopricer",
     "user": "postgres",
     "password": "database password"
   },

--- a/modules/routes/pnl.js
+++ b/modules/routes/pnl.js
@@ -19,7 +19,7 @@ module.exports = function (app, config, configManager) {
 
     return {
       pollDataPath: path.resolve(
-        selectedBot.tf2autobotPath || selectedBot.tf2AutobotDir,
+        selectedBot.tf2autobotPath+"/files/" || selectedBot.tf2AutobotDir+"/files/",
         selectedBot.botDirectory || selectedBot.botTradingDir,
         'polldata.json'
       ),

--- a/modules/routes/trades.js
+++ b/modules/routes/trades.js
@@ -25,7 +25,7 @@ module.exports = function (app, config, configManager) {
       }
 
       const pollDataPath = path.resolve(
-        selectedBot.tf2autobotPath || selectedBot.tf2AutobotDir,
+        selectedBot.tf2autobotPath+"/files/" || selectedBot.tf2AutobotDir+"/files/",
         selectedBot.botDirectory || selectedBot.botTradingDir,
         'polldata.json'
       );


### PR DESCRIPTION
I have fixed the default database name to match the one in your install guide. 

I have also fixed so that it finds the correct folder for the polldata to watch the profit/loss tab and trade history. 